### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["u24", "u40", "u72", "unaligned", "integer"]
 categories = ["data-structures"]
 description = "Unaligned unsigned integers with exact size in memory and arithmetic operations for them"
 readme = "README.md"
-homepage = "https://github.com/AlexanderSchuetz97/uintx"
+repository = "https://github.com/AlexanderSchuetz97/uintx"
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).